### PR TITLE
Support zig v0.10 and upgrade zig-clap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+zig-cache/
+zig-out/
+/release/
+/debug/
+/build/
+/build-*/
+/docgen_tmp/

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ csv2json is a fast utility that converts CSV files into JSON line files.
 # 272376070,1063969,"EURINR21DECFUT","","EURINR",0,"2021-12-29",0,0.0025,1,"FUT","BCD-FUT","BCD"
 # ...
 
-$ ./csv2json -i /tmp/1mil.csv > /tmp/1mil.json                                
+$ ./csv2json -i /tmp/1mil.csv > /tmp/1mil.json
 Reading /tmp/1mil.csv ...
 Processed 1000000 lines in 884.61 milliseconds (1000000.00 lines / second)
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -55,7 +55,6 @@ pub fn main() !void {
 
     const parsers = comptime .{
         .STR = clap.parsers.string,
-        .BOOL = clap.parsers.enumeration(IsArray),
         .INT = clap.parsers.int(u32, 0),
     };
 


### PR DESCRIPTION
Hello,
Thank you for this project. It seemed quite a handy utitlity but wasn't working with zig v0.10.1 so I took a shot on doing so. Hope thats okay.

Here are some of the things I had to do:
- Updated zig-clap to v0.6 (with zig 0.11 release, we will no longer require submodule.)
- allocators are now a function in zig. So instead of passing around a pointer, you should simply pass the allocator in `Converter.init()`. Ofc, that will require changing the type signature.
- Having a custom parser makes this utility a lot more safe. 
- Removed `--array <array>` flag as I couldn't see any logic around existing code. It seemed like a redundant flag to me.
- Also, I've renamed `<UINT32>` to `<INT>` in help msg because it seems more like an implementation detail. It still supports u32 but users don't need to know about it (I think). Happy to revert this change if you think otherwise. I'm not opinionated about such a change.

With the above changes, it seems to be working just fine:
```
~/temp/csv2json master*
λ ./zig-out/bin/csv2json -a true -i /tmp/records.csv > /tmp/records.json
Reading /tmp/records.csv ...
Processed 500001 lines in 7.81 seconds (64041.62 lines / second) # ps. I am running this on a very old laptop

# And for incorrect flag
~/temp/csv2json master* 20s
λ ./zig-out/bin/csv2json -c 1 -i /tmp/records.csv > /tmp/records.json # -c flag does not exist
Invalid flags: InvalidArgument

Convert CSV to JSON files.
    -h, --help
            Display this help and exit.

    -i, --in <STR>
            Path to input CSV file.

    -b, --buf <INT>
            Line buffer (default: 4096). Should be greater than the longest line.
```
